### PR TITLE
Added support for IDE's and shadow builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,6 @@ add_custom_command(
 
 # run lemon
 add_custom_target(parser
-    #OUTPUT ${CMAKE_BINARY_DIR}/parser.c   OUTPUT ${CMAKE_BINARY_DIR}/parser.c
     COMMAND lemon ${CMAKE_BINARY_DIR}/parser.y
     DEPENDS ${CMAKE_BINARY_DIR}/parser.y
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
@@ -21,8 +20,13 @@ add_custom_target(parser
 add_custom_command(
     OUTPUT ${CMAKE_BINARY_DIR}/lexer.cpp
     COMMAND ragel ${CMAKE_SOURCE_DIR}/lexer.rl -o ${CMAKE_BINARY_DIR}/lexer.cpp
+    DEPENDS ${CMAKE_SOURCE_DIR}/lexer.rl
 )
 
+add_custom_target(IDE SOURCES
+    parser.y
+    lexer.rl
+    )
 
 # build executable
 add_executable(calc ${CMAKE_BINARY_DIR}/lexer.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 2.8)
+PROJECT(simplecalc)
+
+
+# copy parser.y to build directory. We want a shaddow build that does not litter
+# the source directory
+add_custom_command(
+    OUTPUT ${CMAKE_BINARY_DIR}/parser.y
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/parser.y ${CMAKE_BINARY_DIR}/parser.y
+    DEPENDS ${CMAKE_SOURCE_DIR}/parser.y)
+
+# run lemon
+add_custom_target(parser
+    #OUTPUT ${CMAKE_BINARY_DIR}/parser.c   OUTPUT ${CMAKE_BINARY_DIR}/parser.c
+    COMMAND lemon ${CMAKE_BINARY_DIR}/parser.y
+    DEPENDS ${CMAKE_BINARY_DIR}/parser.y
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+)
+
+# run ragel
+add_custom_command(
+    OUTPUT ${CMAKE_BINARY_DIR}/lexer.cpp
+    COMMAND ragel ${CMAKE_SOURCE_DIR}/lexer.rl -o ${CMAKE_BINARY_DIR}/lexer.cpp
+)
+
+
+# build executable
+add_executable(calc ${CMAKE_BINARY_DIR}/lexer.cpp)
+
+add_dependencies(calc parser )

--- a/lexer.rl
+++ b/lexer.rl
@@ -6,11 +6,6 @@
 #include <stdlib.h>
 #include "parser.c"
 
-std::string getStr(const char* beg, const char* end)
-{
-    return std::string(beg).substr(0, end-beg);
-}
-
 
 %%{
 
@@ -46,7 +41,7 @@ action closep_tok {
 }
 
 action number_tok{ 
-   Parse(lparser, DOUBLE, atof(getStr(ts, te).c_str()));
+   Parse(lparser, DOUBLE, atof(std::string(ts, te).c_str()));
 }
 
 number = [0-9]+('.'[0-9]+)?;


### PR DESCRIPTION
Using CMake instead of plain make allows for using shadow builds
and provides integration with many IDE's like Qt Creator, Eclipse
Visual Studio etc.
